### PR TITLE
Updating value.converter in the source connector yaml section

### DIFF
--- a/docs/src/pages/scenarios/connect-s3/index.mdx
+++ b/docs/src/pages/scenarios/connect-s3/index.mdx
@@ -273,7 +273,7 @@ spec:
   tasksMax: 1
   config:
     key.converter: org.apache.kafka.connect.storage.StringConverter
-    value.converter: org.apache.camel.kafkaconnector.converters.S3ObjectConverter
+    value.converter: org.apache.camel.kafkaconnector.awss3.converters.S3ObjectConverter
     topics: my-target-topic
     camel.source.kafka.topic: my-target-topic
     camel.source.url: aws-s3://my-s3-bucket?autocloseBody=false


### PR DESCRIPTION
Due to some refactoring it looks like we need to change the value.converter to accomodate for the new location of the S3Object Converter.

class: org.apache.camel.kafkaconnector.CamelSourceConnector or class: org.apache.camel.kafkaconnector.awss3.CamelAwss3SourceConnector seems to be irrelevant.